### PR TITLE
Add SSH Key Rotation and Password Expirations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,121 @@ Provides a script (show_users.yml) for listing all accounts on hosts. For all ho
 
 NOTE: This assumes you're not using LDAP; using this against LDAP-bound servers may result in unintended consequences.
 
-## Usage
+## Usage Examples
+
+### Get All Accounts on Hosts
+#### Example Command
 ```bash
-# Get all accounts in the host list
 ansible-playbook -i inventory.ini -u root show_users.yml
+```
 
-# Set all non-system user passwords to a hard-coded string
+#### Result
+```bash
+TASK [Get a list of all users] *****************************************************************************************************************************************************************
+changed: [test4]
+changed: [test1]
+changed: [test3]
+changed: [test2]
+
+TASK [Show all users] **************************************************************************************************************************************************************************
+ok: [test3]
+ok: [test1]
+ok: [test2]
+ok: [test4]
+
+TASK [debug] ***********************************************************************************************************************************************************************************
+ok: [test1] => {
+    "system_users": [
+        "root:x:0:0:root:/root:/bin/bash",
+        "daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin",
+        "bin:x:2:2:bin:/bin:/usr/sbin/nologin",
+        [SNIP]
+ok: [test2] => {
+        [SNIP]
+ok: [test3] => { 
+        [SNIP]
+ok: [test4] => {
+        [SNIP]
+
+PLAY RECAP *************************************************************************************************************************************************************************************
+test1                      : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+test2                      : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+test3                      : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+test4                      : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+
+### Set all non-system user passwords to a hard-coded string
+#### Example Command
+```bash
 ansible-playbook -i inventory.ini -u root reset_passwords.yml
+```
 
-# Pass in a password
-ansible-playbook -i inventory.ini -u root -e "change_password=password1" reset_passwords.yml
+#### Result
+```bash
+TASK [Fetch non-system users] ******************************************************************************************************************************************************************
+ok: [test3]
+ok: [test4]
+ok: [test2]
+ok: [test1]
+
+TASK [Set the same password for all non-system users] ******************************************************************************************************************************************
+changed: [test4] => (item=user1)
+changed: [test3] => (item=user1)
+[SNIP]
+changed: [test2] => (item=user3)
+
+PLAY RECAP *************************************************************************************************************************************************************************************
+test1                      : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+test2                      : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+test3                      : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+test4                      : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
+```
+After which, you can test that the change had the intended effect:
+```bash
+# using ssh
+ssh user1@localhost -p 2222
+    # enter new password to test
+# OR while already on the container
+su user1
+Password: # Enter new password to test
+```
+
+### Pass in a password
+#### Example Command
+```bash
+ansible-playbook -i inventory.ini -u root -e "change_password=password1!" reset_passwords.yml
+```
+#### Result
+All hosts and user accounts are changed to the new password passed in as the environment
+```bash
+TASK [Fetch non-system users] ******************************************************************************************************************************************************************
+ok: [test3]
+ok: [test4]
+ok: [test2]
+ok: [test1]
+
+TASK [Set the same password for all non-system users] ******************************************************************************************************************************************
+changed: [test4] => (item=user1)
+changed: [test3] => (item=user1)
+[SNIP]
+changed: [test3] => (item=user3)
+changed: [test2] => (item=user3)
+
+PLAY RECAP *************************************************************************************************************************************************************************************
+test1                      : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+test2                      : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+test3                      : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+test4                      : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+After which, you can test that the change had the intended effect:
+```bash
+# using ssh
+ssh user1@localhost -p 2222
+    # enter new password to test
+# OR while already on the container
+su user1
+Password: # Enter new password to test
 ```
 
 ## Testing Process
@@ -24,7 +129,7 @@ Start the testing environment:
 cd tests
 ./run_tests.sh
 # Hit enter when you want to stop the testing environment
-# Note: it will close all docker containers
+# Note: be careful, it closes stops docker containers on your machine
 ```
 
 Test user passwords in the container(s):
@@ -35,5 +140,5 @@ ssh user1@localhost -p 2222
 When you get locked out and need to troubleshoot:
 ```bash
 docker ps # gets you a list of container ids
-docker exec -it --tty <container id> /bin/bash # Gives you a root shell into the container
+docker exec -it --tty <container id> /bin/bash # Gives you a root shell into the specified container
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mass Password Changer
 
-Provides a script (show_users.yml) for listing all accounts on hosts. For all hosts, you can set a new password (reset_password.yml) for all non-system users. This functionality provides you a nuclear option for fast containment and recovery when dealing with an incident.
+Provides a script (show_users.yml) for listing all accounts on hosts. For all hosts, you can set a new password and SSH public key (reset_password.yml) for all non-system users (all users will need to reset their password after first login). This functionality provides you a nuclear option for fast containment and recovery when dealing with an incident.
 
 NOTE: This assumes you're not using LDAP; using this against LDAP-bound servers may result in unintended consequences.
 

--- a/reset_passwords.yml
+++ b/reset_passwords.yml
@@ -4,6 +4,7 @@
   become: yes
   vars:
     change_password: ChangeMeNow! # override with -e option
+    change_sshkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBznwIb7wGsPVKqUqehpBK7wpUBHaiqU1HQEwfc48LzP
     # TODO: set this dynamically, so each user gets a unique password
   tasks:
     - name: Fetch non-system users
@@ -11,6 +12,7 @@
       register: users
       changed_when: false
 
+    # Set the same password for all non-system users
     - name: Set the same password for all non-system users
       user:
         name: "{{ item }}"
@@ -19,4 +21,40 @@
       with_items: "{{ users.stdout_lines }}"
       when: users.stdout_lines is defined and users.stdout_lines | length > 0
 
-    # TODO: consider ssh keys in ~/.ssh/authorized_keys
+    # Force changing password on next login
+    - name: Force Password Expiration
+      command: "chage -d 0 {{ item }}"
+      when: users.stdout_lines is defined and users.stdout_lines | length > 0
+      with_items: "{{ users.stdout_lines }}"
+
+    # Ensure existence of ~/.ssh/authorized_keys
+    - name: Ensure user has /home/<user>/.ssh/authorized_keys
+      stat:
+        path: "/home/{{ item }}/.ssh/authorized_keys"
+      register: auth_key_stat
+      with_items: "{{ users.stdout_lines }}"
+      when: users.stdout_lines is defined and users.stdout_lines | length > 0
+
+    # Back up existing authorized_keys file
+    - name: Backup existing authorized_keys file to authorized_keys.old
+      copy:
+        src: "/home/{{ item.item }}/.ssh/authorized_keys"
+        dest: "/home/{{ item.item }}/.ssh/authorized_keys.old"
+        remote_src: yes
+        owner: "{{ item.item }}"
+        group: "{{ item.item }}"
+        mode: preserve
+      register: backup
+      with_items: "{{ auth_key_stat.results }}"
+      when: "item.stat.exists"
+    
+    # Replace authorized_key file with our own
+    - name: Replace content of authorized_keys file with a new SSH key
+      copy:
+        dest: "/home/{{ item.item }}/.ssh/authorized_keys"
+        content: "{{ change_sshkey }}"
+        owner: "{{ item.item }}"
+        group: "{{ item.item }}"
+        mode: '0600'
+      with_items: "{{ auth_key_stat.results }}"
+      when: "item.stat.exists and backup is defined"

--- a/show_users.yml
+++ b/show_users.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: test_hosts
+- hosts: all
   gather_facts: no
   become: yes  # This makes Ansible use sudo to execute commands as root
   tasks:

--- a/tests/test_hosts.ini
+++ b/tests/test_hosts.ini
@@ -1,3 +1,7 @@
+[all:vars]
+ansible_connection=ssh
+ansible_user=root
+
 [test_hosts]
 test1 ansible_host=localhost ansible_ssh_port=2222 ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 test2 ansible_host=localhost ansible_ssh_port=2223 ansible_ssh_common_args='-o StrictHostKeyChecking=no'


### PR DESCRIPTION
Adds the following:
- All users affected by password reset will need to change their password on first login
- All hosts and users with `~/.ssh/authorized_keys` file will have those keys backed up to `~/.ssh/authorized_keys.old`
- All hosts and users with `~/.ssh/authorized_keys` file will have their public keys replaced by the one defined in the ansible script.